### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,17 +21,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0
 
     - name: Cache Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3.2.3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-maven-
 
     - name: Cache Gradle downloads
-      uses: actions/cache@v2
+      uses: actions/cache@v3.2.3
       with:
         path: |
           ~/.gradle/caches
@@ -41,7 +41,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialise CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@codeql-bundle-20230105
       #with:
       #  languages: ['cpp', 'java']
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -77,4 +77,4 @@ jobs:
        exit $rv
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@codeql-bundle-20230105


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.2.3](https://github.com/actions/cache/releases/tag/v3.2.3)** on 2023-01-09T05:38:51Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230105](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230105)** on 2023-01-06T15:03:08Z
