### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@
           "uses": "actions/checkout@v3.3.0"
         },
         {
-          "uses": "nttld/setup-ndk@v1",
+          "uses": "nttld/setup-ndk@v1.2.0",
           "with": {
             "ndk-version": "22.1.7171670"
           }


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[nttld/setup-ndk](https://github.com/nttld/setup-ndk)** published a new release **[v1.2.0](https://github.com/nttld/setup-ndk/releases/tag/v1.2.0)** on 2022-10-17T08:08:51Z
